### PR TITLE
fix(): tile-link API call which was failing

### DIFF
--- a/common/services/deviceOperation.js
+++ b/common/services/deviceOperation.js
@@ -236,6 +236,7 @@ export default {
           skipAuthorization: true,
           headers: {
             Authorization: "Bearer " + localStorage.token,
+            'Content-Type': 'application/json',
           },
         }
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
-  "version": "1.1.8",
+  "version": "1.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@doordeck/javascript-doordeck-sdk",
-      "version": "1.1.8",
+      "version": "1.1.10",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1js": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
   "title": "Javascript Doordeck Sdk",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Javascript wrapper for the Doordeck SDK.",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
fix(): tile-link API call which was failing due to content type is automatically set to application/x-www-form-urlencoded

Server responds was:
`{"code":415,"message":"HTTP 415 Unsupported Media Type"}`