### PR TITLE
Fix/split endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ import doordeckSdk from '@doordeck/javascript-doordeck-sdk'
 
 // Initialise the SDK with your AuthToken
 // 'AuthToken': Base64 encoded Ed25519 public key
+// 'BaseUrl' : Base URL for the Doordeck SDK. If 'null' then the production URL is going to be used.
 
-doordeckSdk.initDoordeck(authToken).then(response => {
+doordeckSdk.doordeckInit(authToken, baseUrl).then(response => {
 	// doordeck successfully initialised
 }, error => {
 	if (error.state === 'verify') {

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,4 +1,5 @@
-export const BASE_URL = 'https://api.doordeck.com'
+export const DEFAULT_BASE_URL = 'https://api.doordeck.com'
+export const BASE_URL = '4zA64daKfi'
 export const EPHEMERAL_PRIKEY = 'S8Y0bEpu4y'
 export const EPHEMERAL_PUBKEY = '4yA64dfKfi'
 export const AUTH_TOKEN = '2uGGg077YR'

--- a/common/doordeck.js
+++ b/common/doordeck.js
@@ -1,51 +1,61 @@
-import { AUTH_TOKEN } from './constants'
+import {AUTH_TOKEN, BASE_URL, DEFAULT_BASE_URL} from './constants'
 import ephemaralKeyGenerator from './services/ephemeralKeyGenerator'
 import certificate from './services/certificate'
 import libSodium from 'libsodium-wrappers'
 import device from "./services/deviceOperation";
 
 const isLoaded = async function (authToken) {
-  if (authToken === getStoredAuthToken()) {
-    if (ephemaralKeyGenerator.retrieveSavedKeys() !== null) {
-      return (await certificate.retrieveSavedCert()) !== null;
+    if (authToken === getStoredAuthToken()) {
+        if (ephemaralKeyGenerator.retrieveSavedKeys() !== null) {
+            return (await certificate.retrieveSavedCert()) !== null;
+        } else return false
     } else return false
-  } else return false
 }
 
-const doordeckInit = function (authToken) {
-  return new Promise (function(resolve, reject) {
-    libSodium.ready.then(async function () {
-      if ((await isLoaded())) resolve({state: 'success', message: 'Doordeck is already initialised.'})
-      if (authToken !== null && authToken !== undefined) {
-        storeAuthToken(authToken)
-        ephemaralKeyGenerator.generateKeys().then(keys => {
-          certificate.getCertificate(keys).then(response => {
-            resolve(response)
-          }, fail => {
-            reject(fail)
-          })
+const doordeckInit = function (authToken, baseUrl) {
+    return new Promise(function (resolve, reject) {
+        libSodium.ready.then(async function () {
+            if ((await isLoaded())) resolve({state: 'success', message: 'Doordeck is already initialised.'})
+            if (authToken !== null && authToken !== undefined) {
+                storeBaseUrl(baseUrl)
+                storeAuthToken(authToken)
+                ephemaralKeyGenerator.generateKeys().then(keys => {
+                    certificate.getCertificate(keys).then(response => {
+                        resolve(response)
+                    }, fail => {
+                        reject(fail)
+                    })
+                })
+            } else reject({state: 'error', message: 'No Auth Token provided.'})
         })
-      } else reject({state: 'error', message: 'No Auth Token provided.'})
     })
-  })
 }
 
 const storeAuthToken = function (authToken) {
-  localStorage[AUTH_TOKEN] = authToken
+    localStorage[AUTH_TOKEN] = authToken
+}
+
+const storeBaseUrl = function (baseUrl) {
+    localStorage[BASE_URL] = baseUrl
+}
+
+const getBaseUrl = function () {
+    return localStorage[BASE_URL] || DEFAULT_BASE_URL
 }
 
 const getStoredAuthToken = function () {
-  return localStorage[AUTH_TOKEN]
+    return localStorage[AUTH_TOKEN]
 }
 
 
 const verifyCode = function (code) {
-  return certificate.verifyCode(code, ephemaralKeyGenerator.retrieveSavedKeys())
+    return certificate.verifyCode(code, ephemaralKeyGenerator.retrieveSavedKeys())
 }
 
 export default {
-  doordeckInit,
-  verifyCode,
-  device,
-  libSodium
+    doordeckInit,
+    verifyCode,
+    device,
+    libSodium,
+    getBaseUrl,
 }

--- a/common/services/certificate.js
+++ b/common/services/certificate.js
@@ -1,4 +1,4 @@
-import {AUTH_TOKEN, BASE_URL, CERT} from '../constants'
+import {AUTH_TOKEN, CERT} from '../constants'
 
 import IDB from '../idb'
 import axios from 'axios'
@@ -13,124 +13,123 @@ import {fromBER} from "asn1js";
  * if this cert is expiring in less than a week. If so, we'll
  * delete it, and we'll return @null to force a new certificate
  */
+const _certAccordingToValidity = async function (certObject) {
+    let base64DerCertificate = certObject["certificateChain"][0];
+    const base64DerCertificateArrayBuffer = Uint8Array.from(atob(base64DerCertificate), c => c.charCodeAt(0)).buffer;
 
-const _certAccordingToValidity = async function(certObject) {
-  let base64DerCertificate = certObject["certificateChain"][0];
-  const base64DerCertificateArrayBuffer = Uint8Array.from(atob(base64DerCertificate), c => c.charCodeAt(0)).buffer;
+    try {
+        const asn1 = fromBER(base64DerCertificateArrayBuffer);
+        const cert = new Certificate({schema: asn1.result});
 
-  try {
-    const asn1 = fromBER(base64DerCertificateArrayBuffer);
-    const cert = new Certificate({ schema: asn1.result });
+        const endDate = cert.notAfter.value;
+        const currentDate = new Date();
+        const weekFromNow = new Date(currentDate);
+        weekFromNow.setDate(currentDate.getDate() + 7);
 
-    const endDate = cert.notAfter.value;
-    const currentDate = new Date();
-    const weekFromNow = new Date(currentDate);
-    weekFromNow.setDate(currentDate.getDate() + 7);
-
-    if (endDate < weekFromNow) {
-      // Delete cert, return null to force getting a new one.
-      await deleteCert();
-      return null;
-    } else {
-      return certObject;
+        if (endDate < weekFromNow) {
+            // Delete cert, return null to force getting a new one.
+            await deleteCert();
+            return null;
+        } else {
+            return certObject;
+        }
+    } catch (error) {
+        // We don't care, there wasn't probably a proper cert here
+        return null;
     }
-  } catch (error) {
-    // We don't care, there wasn't probably a proper cert here
-    return null;
-  }
 }
 
 const retrieveSavedCert = async function () {
-  const email = localStorage.email;
-  if(!email) return null
-  const cert = await IDB.get(email)
-  if(cert) {
-    localStorage[CERT] = JSON.stringify(cert)
-    return await _certAccordingToValidity(cert)
-  }
-  return null
+    const email = localStorage.email;
+    if (!email) return null
+    const cert = await IDB.get(email)
+    if (cert) {
+        localStorage[CERT] = JSON.stringify(cert)
+        return await _certAccordingToValidity(cert)
+    }
+    return null
 }
 const storeCert = function (cert) {
-  localStorage[CERT] = JSON.stringify(cert)
-  // update cert in indexedDB
-  const email = localStorage.email;
-  IDB.set(email, cert)
+    localStorage[CERT] = JSON.stringify(cert)
+    // update cert in indexedDB
+    const email = localStorage.email;
+    IDB.set(email, cert)
 }
 
-const deleteCert = async function() {
-  localStorage.removeItem(CERT);
-  await IDB.deleteDatabase();
+const deleteCert = async function () {
+    localStorage.removeItem(CERT);
+    await IDB.deleteDatabase();
 }
 
 const registerCertificate = function (pubKey) {
-  var ephKey = doordeck.libSodium.to_base64(pubKey, doordeck.libSodium.base64_variants.ORIGINAL)
-  return axios.post(BASE_URL + '/auth/certificate', {
-    'ephemeralKey': ephKey
-  }, {
-    headers: {
-      'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
-    }
-  })
+    const ephKey = doordeck.libSodium.to_base64(pubKey, doordeck.libSodium.base64_variants.ORIGINAL);
+    return axios.post(doordeck.getBaseUrl() + '/auth/certificate', {
+        'ephemeralKey': ephKey
+    }, {
+        headers: {
+            'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
+        }
+    })
 }
-const registerCertificate2FA = function(pubKey) {
-  var ephKey = doordeck.libSodium.to_base64(pubKey, doordeck.libSodium.base64_variants.ORIGINAL)
-  return axios.post(BASE_URL + '/auth/certificate/verify', {
-    'ephemeralKey': ephKey
-  }, {
-    headers: {
-      'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
-    }
-  })
+const registerCertificate2FA = function (pubKey) {
+    const ephKey = doordeck.libSodium.to_base64(pubKey, doordeck.libSodium.base64_variants.ORIGINAL);
+    return axios.post(doordeck.getBaseUrl() + '/auth/certificate/verify', {
+        'ephemeralKey': ephKey
+    }, {
+        headers: {
+            'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
+        }
+    })
 }
-const verify2FA = function(code, priKey) {
-  var signature = doordeck.libSodium.crypto_sign_detached(code, priKey)
-  return axios.post(BASE_URL + '/auth/certificate/check', {
-    'verificationSignature': doordeck.libSodium.to_base64(signature, doordeck.libSodium.base64_variants.ORIGINAL)
-  }, {
-    headers: {
-      'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
-    }
-  })
+const verify2FA = function (code, priKey) {
+    const signature = doordeck.libSodium.crypto_sign_detached(code, priKey);
+    return axios.post(doordeck.getBaseUrl() + '/auth/certificate/check', {
+        'verificationSignature': doordeck.libSodium.to_base64(signature, doordeck.libSodium.base64_variants.ORIGINAL)
+    }, {
+        headers: {
+            'Authorization': 'Bearer ' + localStorage[AUTH_TOKEN]
+        }
+    })
 }
 
 export default {
-  getCertificate (ephemeralKey) {
-    return new Promise (async function(resolve, reject) {
-      const cert = await retrieveSavedCert()
-      if (cert == null && cert == undefined) {
-        registerCertificate(ephemeralKey.publicKey)
-        .then(response => {
-          storeCert(response.data)
-          resolve({state: 'success', message: 'Doordeck SDK is loaded'})
-        })
-        .catch(fail => {
-          if (fail.response.status === 423) {
-            if (localStorage.token !== null && localStorage.token !== undefined) {
-              registerCertificate2FA(ephemeralKey.publicKey).then(response => {
-                if (response.data.method !== undefined && response.data.method !== null) {
-                  reject({state: 'verify', method: response.data.method})
-                } else reject({state: 'error', message: 'Failed to send 2FA request'})
-              })
+    getCertificate(ephemeralKey) {
+        return new Promise(async function (resolve, reject) {
+            const cert = await retrieveSavedCert()
+            if (cert == null && cert == undefined) {
+                registerCertificate(ephemeralKey.publicKey)
+                    .then(response => {
+                        storeCert(response.data)
+                        resolve({state: 'success', message: 'Doordeck SDK is loaded'})
+                    })
+                    .catch(fail => {
+                        if (fail.response.status === 423) {
+                            if (localStorage.token !== null && localStorage.token !== undefined) {
+                                registerCertificate2FA(ephemeralKey.publicKey).then(response => {
+                                    if (response.data.method !== undefined && response.data.method !== null) {
+                                        reject({state: 'verify', method: response.data.method})
+                                    } else reject({state: 'error', message: 'Failed to send 2FA request'})
+                                })
+                            }
+                        } else {
+                            reject({state: 'error', message: 'Failed to get certificate'})
+                        }
+                    })
+            } else {
+                resolve({state: 'success', message: 'Doordeck SDK is loaded'})
             }
-          } else {
-            reject({state: 'error', message: 'Failed to get certificate'})
-          }
         })
-      } else {
-        resolve({state: 'success', message: 'Doordeck SDK is loaded'})
-      }
-    })
-  },
-  verifyCode (code, ephemeralKey) {
-    return new Promise (function(resolve, reject) {
-      verify2FA(code, ephemeralKey.privateKey).then(response => {
-        storeCert(response.data)
-        resolve({state: 'success', message: 'Doordeck SDK is loaded'})
-      }, fail => {
-        reject({state: 'fail', message: 'Something went wrong'})
-      })
-    })
-  },
-  retrieveSavedCert,
-  deleteCert
+    },
+    verifyCode(code, ephemeralKey) {
+        return new Promise(function (resolve, reject) {
+            verify2FA(code, ephemeralKey.privateKey).then(response => {
+                storeCert(response.data)
+                resolve({state: 'success', message: 'Doordeck SDK is loaded'})
+            }, fail => {
+                reject({state: 'fail', message: 'Something went wrong'})
+            })
+        })
+    },
+    retrieveSavedCert,
+    deleteCert
 }

--- a/common/services/deviceOperation.js
+++ b/common/services/deviceOperation.js
@@ -1,252 +1,252 @@
 // noinspection JSUnusedGlobalSymbols,JSCheckFunctionSignatures
 
 import axios from "axios";
-import { CERT } from "../constants";
+import {CERT} from "../constants";
 import ephemaralKeyGenerator from "./ephemeralKeyGenerator";
-import doordeckSDK from "../doordeck";
+import doordeck from "../doordeck";
 
 const _signer = function (deviceId, operation) {
-  // Retrieve the EdDSA private key from storage
-  const privateKey = ephemaralKeyGenerator.retrieveSavedKeys().privateKey
+    // Retrieve the EdDSA private key from storage
+    const privateKey = ephemaralKeyGenerator.retrieveSavedKeys().privateKey
 
-  // Header
-  // noinspection JSUnresolvedVariable
-  const oHeader = {
-    alg: "EdDSA",
-    typ: "JWT",
-    x5c: JSON.parse(localStorage[CERT]).certificateChain,
-  };
+    // Header
+    // noinspection JSUnresolvedVariable
+    const oHeader = {
+        alg: "EdDSA",
+        typ: "JWT",
+        x5c: JSON.parse(localStorage[CERT]).certificateChain,
+    };
 
-  // Payload
-  const tNow = Math.floor(Date.now() / 1000)
-  const tEnd = tNow + 60
-  const oPayload = {
-    iss: JSON.parse(localStorage[CERT]).userId,
-    sub: deviceId,
-    nbf: tNow,
-    iat: tNow,
-    exp: tEnd,
-    operation: operation
-  }
-  // noinspection JSUnresolvedVariable,JSUnresolvedFunction
-  const sHeader = doordeckSDK.libSodium.to_base64(
-      JSON.stringify(oHeader),
-      doordeckSDK.libSodium.base64_variants.URLSAFE_NO_PADDING,
-  )
-  // noinspection JSUnresolvedVariable,JSUnresolvedFunction
-  const sPayload = doordeckSDK.libSodium.to_base64(
-      JSON.stringify(oPayload),
-      doordeckSDK.libSodium.base64_variants.URLSAFE_NO_PADDING,
-  )
-  const message = sHeader + '.' + sPayload
-  // noinspection JSUnresolvedVariable,JSUnresolvedFunction
-  const signature = doordeckSDK.libSodium.crypto_sign_detached(message, privateKey)
-  // noinspection JSUnresolvedVariable,JSUnresolvedFunction
-  return message + '.' + doordeckSDK.libSodium.to_base64(
-      signature,
-      doordeckSDK.libSodium.base64_variants.URLSAFE_NO_PADDING,
-  )
-};
-const _executor = function (baseUrl, deviceId, operation) {
-  const signature = _signer(deviceId, operation);
-  return axios.post(
-      baseUrl + "/device/" + deviceId + "/execute",
-      signature,
-      {
-        headers: {
-          Authorization: "Bearer " + localStorage.token,
-          "Content-Type": "application/jwt",
-        },
-        transformRequest: [
-          (data) => data // Somehow this has to be like that, otherwise the default transformation does its own job
-        ],
-        timeout: 10000
-      }
-  );
-};
-const _getUserByEmail = function (baseUrl, userEmail, visitor) {
-  let url = baseUrl + "/share/invite/" + userEmail;
-  if (visitor !== undefined) {
-    url += "?visitor=" + visitor;
-  }
-  return axios.post(url, null, {
-    skipAuthorization: true,
-    headers: {
-      'Authorization': "Bearer " + localStorage.token,
-      'Content-Type': 'application/json'
-    },
-  })
-      .then((response) => {
-        return response;
-      });
-};
-const _getUserById = function (baseUrl, id) {
-  return axios
-      .post(
-          baseUrl + "/directory/query",
-          { localKey: id },
-          {
-            skipAuthorization: true,
-            headers: {
-              Authorization: "Bearer " + localStorage.token,
-            },
-          }
-      )
-      .then((response) => {
-        return response;
-      });
-};
-export default {
-  lock(baseUrl, deviceId) {
-    return _executor(baseUrl, deviceId, {
-      type: "MUTATE_LOCK",
-      locked: true,
-    });
-  },
-  unlock(baseUrl, deviceId, duration) {
-    return _executor(baseUrl, deviceId, {
-      type: "MUTATE_LOCK",
-      locked: false,
-      duration: duration,
-    });
-  },
-  changeOpenHours(baseUrl, deviceId, settings) {
-    return _executor(baseUrl, deviceId, {
-      type: "MUTATE_SETTING",
-      unlockBetween: settings,
-    });
-  },
-  changeUnlockTime(baseUrl, deviceId, time) {
-    return _executor(baseUrl, deviceId, {
-      type: "MUTATE_SETTING",
-      unlockDuration: parseInt(time),
-    });
-  },
-  remove(baseUrl, deviceId, users) {
-    return _executor(baseUrl, deviceId, {
-      type: "REMOVE_USER",
-      users: users,
-    });
-  },
-  /* eslint-disable */
-  getUser(baseUrl, user) {
-    const emailRegex =
-        /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-    if (emailRegex.test(user)) {
-      return _getUserByEmail(baseUrl, user).then((response) => {
-        response.data = { user: response.data, email: user };
-        return response;
-      });
-    } else {
-      const uuidRegex =
-          /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-      if (uuidRegex.test(user)) {
-        return _getUserById(baseUrl, user).then((response) => {
-          response.data = { user: response.data, email: user };
-          return response;
-        });
-      }
+    // Payload
+    const tNow = Math.floor(Date.now() / 1000)
+    const tEnd = tNow + 60
+    const oPayload = {
+        iss: JSON.parse(localStorage[CERT]).userId,
+        sub: deviceId,
+        nbf: tNow,
+        iat: tNow,
+        exp: tEnd,
+        operation: operation
     }
-  },
-  getDoordeckUser (baseUrl, user, visitor) {
-    var emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
-    if (emailRegex.test(user)) {
-      return _getUserByEmail(baseUrl, user, visitor).then(response => {
-        var data = {'user': response.data, 'email': user}
-        response.data = data
-        return response
-      })
-    } else {
-      var uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
-      if (uuidRegex.test(user)) {
-        return _getUserById(baseUrl, user).then(response => {
-          var data = {'user': response.data, 'email': user}
-          response.data = data
-          return response
-        })
-      }
-    }
-  },
-  share(baseUrl, deviceId, user, role, start, end) {
-    if (start == null && end == null) {
-      return _executor(baseUrl, deviceId, {
-        type: "ADD_USER",
-        publicKey: user.publicKey,
-        user: user.userId,
-        role: role,
-      }).then((response) => {
-        const share = {};
-        share.id = deviceId;
-        share.email = user.email;
-        response.data = share;
-        return response;
-      });
-    } else {
-      return _executor(baseUrl, deviceId, {
-        type: "ADD_USER",
-        publicKey: user.publicKey,
-        user: user.userId,
-        role: role,
-        start: start,
-        end: end,
-      }).then((response) => {
-        const share = {};
-        share.id = deviceId;
-        share.email = user.email;
-        response.data = share;
-        return response;
-      });
-    }
-  },
-  changeRole(baseUrl, deviceId, user, role) {
-    return _executor(baseUrl, deviceId, {
-      type: "ADD_USER",
-      publicKey: user.publicKey,
-      user: user.userId,
-      role: role,
-    }).then((response) => {
-      const share = {};
-      share.id = deviceId;
-      share.email = user.email;
-      response.data = share;
-      return response;
-    });
-  },
-  getLockFromTile(baseUrl, tileId) {
-    return axios.get(baseUrl + "/tile/" + tileId, {
-      skipAuthorization: true,
-      headers: {
-        Authorization: "Bearer " + localStorage.token,
-        Accept: "application/vnd.doordeck.api-v3+json"
-      },
-    });
-  },
-  getLockInfo(baseUrl, lockId) {
-    return axios.get(baseUrl + "/device/" + lockId, {
-      headers: {
-        Authorization: "Bearer " + localStorage.token,
-      },
-    });
-  },
-  link(baseUrl, deviceId, tileId) {
-    return axios.put(
-        baseUrl + "/device/" + deviceId + "/tile/" + tileId,
-        null,
+    // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+    const sHeader = doordeck.libSodium.to_base64(
+        JSON.stringify(oHeader),
+        doordeck.libSodium.base64_variants.URLSAFE_NO_PADDING,
+    )
+    // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+    const sPayload = doordeck.libSodium.to_base64(
+        JSON.stringify(oPayload),
+        doordeck.libSodium.base64_variants.URLSAFE_NO_PADDING,
+    )
+    const message = sHeader + '.' + sPayload
+    // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+    const signature = doordeck.libSodium.crypto_sign_detached(message, privateKey)
+    // noinspection JSUnresolvedVariable,JSUnresolvedFunction
+    return message + '.' + doordeck.libSodium.to_base64(
+        signature,
+        doordeck.libSodium.base64_variants.URLSAFE_NO_PADDING,
+    )
+};
+const _executor = function (deviceId, operation) {
+    const signature = _signer(deviceId, operation);
+    return axios.post(
+        doordeck.getBaseUrl() + "/device/" + deviceId + "/execute",
+        signature,
         {
-          skipAuthorization: true,
-          headers: {
-            Authorization: "Bearer " + localStorage.token,
-            'Content-Type': 'application/json',
-          },
+            headers: {
+                Authorization: "Bearer " + localStorage.token,
+                "Content-Type": "application/jwt",
+            },
+            transformRequest: [
+                (data) => data // Somehow this has to be like that, otherwise the default transformation does its own job
+            ],
+            timeout: 10000
         }
     );
-  },
-  delink(baseUrl, deviceId, tileId) {
-    return axios.delete(baseUrl + "/device/" + deviceId + "/tile/" + tileId, {
-      skipAuthorization: true,
-      headers: {
-        Authorization: "Bearer " + localStorage.token,
-      },
-    });
-  },
+};
+const _getUserByEmail = function (userEmail, visitor) {
+    let url = doordeck.getBaseUrl() + "/share/invite/" + userEmail;
+    if (visitor !== undefined) {
+        url += "?visitor=" + visitor;
+    }
+    return axios.post(url, null, {
+        skipAuthorization: true,
+        headers: {
+            'Authorization': "Bearer " + localStorage.token,
+            'Content-Type': 'application/json'
+        },
+    })
+        .then((response) => {
+            return response;
+        });
+};
+const _getUserById = function (id) {
+    return axios
+        .post(
+            doordeck.getBaseUrl() + "/directory/query",
+            {localKey: id},
+            {
+                skipAuthorization: true,
+                headers: {
+                    Authorization: "Bearer " + localStorage.token,
+                },
+            }
+        )
+        .then((response) => {
+            return response;
+        });
+};
+export default {
+    lock(deviceId) {
+        return _executor(deviceId, {
+            type: "MUTATE_LOCK",
+            locked: true,
+        });
+    },
+    unlock(deviceId, duration) {
+        return _executor(deviceId, {
+            type: "MUTATE_LOCK",
+            locked: false,
+            duration: duration,
+        });
+    },
+    changeOpenHours(deviceId, settings) {
+        return _executor(deviceId, {
+            type: "MUTATE_SETTING",
+            unlockBetween: settings,
+        });
+    },
+    changeUnlockTime(deviceId, time) {
+        return _executor(deviceId, {
+            type: "MUTATE_SETTING",
+            unlockDuration: parseInt(time),
+        });
+    },
+    remove(deviceId, users) {
+        return _executor(deviceId, {
+            type: "REMOVE_USER",
+            users: users,
+        });
+    },
+    /* eslint-disable */
+    getUser(user) {
+        const emailRegex =
+            /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        if (emailRegex.test(user)) {
+            return _getUserByEmail(user).then((response) => {
+                response.data = {user: response.data, email: user};
+                return response;
+            });
+        } else {
+            const uuidRegex =
+                /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+            if (uuidRegex.test(user)) {
+                return _getUserById(user).then((response) => {
+                    response.data = {user: response.data, email: user};
+                    return response;
+                });
+            }
+        }
+    },
+    getDoordeckUser(user, visitor) {
+        const emailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
+        if (emailRegex.test(user)) {
+            return _getUserByEmail(user, visitor).then(response => {
+                const data = {'user': response.data, 'email': user};
+                response.data = data
+                return response
+            })
+        } else {
+            const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+            if (uuidRegex.test(user)) {
+                return _getUserById(user).then(response => {
+                    const data = {'user': response.data, 'email': user};
+                    response.data = data
+                    return response
+                })
+            }
+        }
+    },
+    share(deviceId, user, role, start, end) {
+        if (start == null && end == null) {
+            return _executor(deviceId, {
+                type: "ADD_USER",
+                publicKey: user.publicKey,
+                user: user.userId,
+                role: role,
+            }).then((response) => {
+                const share = {};
+                share.id = deviceId;
+                share.email = user.email;
+                response.data = share;
+                return response;
+            });
+        } else {
+            return _executor(deviceId, {
+                type: "ADD_USER",
+                publicKey: user.publicKey,
+                user: user.userId,
+                role: role,
+                start: start,
+                end: end,
+            }).then((response) => {
+                const share = {};
+                share.id = deviceId;
+                share.email = user.email;
+                response.data = share;
+                return response;
+            });
+        }
+    },
+    changeRole(deviceId, user, role) {
+        return _executor(deviceId, {
+            type: "ADD_USER",
+            publicKey: user.publicKey,
+            user: user.userId,
+            role: role,
+        }).then((response) => {
+            const share = {};
+            share.id = deviceId;
+            share.email = user.email;
+            response.data = share;
+            return response;
+        });
+    },
+    getLockFromTile(tileId) {
+        return axios.get(doordeck.getBaseUrl() + "/tile/" + tileId, {
+            skipAuthorization: true,
+            headers: {
+                Authorization: "Bearer " + localStorage.token,
+                Accept: "application/vnd.doordeck.api-v3+json"
+            },
+        });
+    },
+    getLockInfo(lockId) {
+        return axios.get(doordeck.getBaseUrl() + "/device/" + lockId, {
+            headers: {
+                Authorization: "Bearer " + localStorage.token,
+            },
+        });
+    },
+    link(deviceId, tileId) {
+        return axios.put(
+            doordeck.getBaseUrl() + "/device/" + deviceId + "/tile/" + tileId,
+            null,
+            {
+                skipAuthorization: true,
+                headers: {
+                    Authorization: "Bearer " + localStorage.token,
+                    'Content-Type': 'application/json',
+                },
+            }
+        );
+    },
+    delink(deviceId, tileId) {
+        return axios.delete(doordeck.getBaseUrl() + "/device/" + deviceId + "/tile/" + tileId, {
+            skipAuthorization: true,
+            headers: {
+                Authorization: "Bearer " + localStorage.token,
+            },
+        });
+    },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@doordeck/javascript-doordeck-sdk",
-      "version": "1.2.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1js": "^3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@doordeck/javascript-doordeck-sdk",
-      "version": "1.1.10",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "asn1js": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
   "title": "Javascript Doordeck Sdk",
-  "version": "1.1.10",
+  "version": "1.2.0",
   "description": "Javascript wrapper for the Doordeck SDK.",
   "main": "index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@doordeck/javascript-doordeck-sdk",
   "title": "Javascript Doordeck Sdk",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Javascript wrapper for the Doordeck SDK.",
   "main": "index.js",
   "author": {


### PR DESCRIPTION
Fixing endpoints where the base url was static

- Bumped the version to `2.0.0`
- Removed `baseUrl` settings from all of the functions
- `BaseUrl` is now set in the `doordeckInit` function and if it is not provided the default prod url is going to be used.